### PR TITLE
Add SORBlock protocol. Parse logic refactoring

### DIFF
--- a/SORParser.xcodeproj/project.pbxproj
+++ b/SORParser.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		41008E6E24EEB377009461B8 /* SORDataPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41008E6D24EEB377009461B8 /* SORDataPoints.swift */; };
 		41008E7024EFC85F009461B8 /* SORCheckSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41008E6F24EFC85F009461B8 /* SORCheckSum.swift */; };
 		9E88DFBD291010D900BD7FE2 /* Test.sor in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9E88DFBB29100E9D00BD7FE2 /* Test.sor */; };
+		9EA41DFA2B851C500063E85D /* SORBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EA41DF92B851C500063E85D /* SORBlock.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +49,7 @@
 		41008E6D24EEB377009461B8 /* SORDataPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SORDataPoints.swift; sourceTree = "<group>"; };
 		41008E6F24EFC85F009461B8 /* SORCheckSum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SORCheckSum.swift; sourceTree = "<group>"; };
 		9E88DFBB29100E9D00BD7FE2 /* Test.sor */ = {isa = PBXFileReference; lastKnownFileType = file; path = Test.sor; sourceTree = "<group>"; };
+		9EA41DF92B851C500063E85D /* SORBlock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SORBlock.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,6 +94,7 @@
 				41008E6B24EE7D3F009461B8 /* SORKeyEvents.swift */,
 				41008E6D24EEB377009461B8 /* SORDataPoints.swift */,
 				41008E6F24EFC85F009461B8 /* SORCheckSum.swift */,
+				9EA41DF92B851C500063E85D /* SORBlock.swift */,
 			);
 			path = SORParser;
 			sourceTree = "<group>";
@@ -154,6 +157,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9EA41DFA2B851C500063E85D /* SORBlock.swift in Sources */,
 				41008E5424EC6491009461B8 /* main.swift in Sources */,
 				41008E6C24EE7D3F009461B8 /* SORKeyEvents.swift in Sources */,
 				41008E6624EE640B009461B8 /* SORGeneralParams.swift in Sources */,

--- a/SORParser/SORBlock.swift
+++ b/SORParser/SORBlock.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol SORBlock {
+    init?(from fileHandle: FileHandle, header: SORBlockHeader)
+}

--- a/SORParser/SORCheckSum.swift
+++ b/SORParser/SORCheckSum.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SORCheckSum {
+struct SORCheckSum: SORBlock {
     let chkSum: UInt16
     init?(from fileHandle: FileHandle, header: SORBlockHeader) {
         if header.version.major == 2 {

--- a/SORParser/SORDataPoints.swift
+++ b/SORParser/SORDataPoints.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SORDataPoints {
+struct SORDataPoints: SORBlock {
     let points: [UInt16]
     init?(from fileHandle: FileHandle, header: SORBlockHeader) {
         if header.version.major == 2 {

--- a/SORParser/SORFixedParams.swift
+++ b/SORParser/SORFixedParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SORFixedParams {
+struct SORFixedParams: SORBlock {
     enum TraceType: String {
         case standardTrace = "ST"
         case reverseTrace = "RT"

--- a/SORParser/SORGeneralParams.swift
+++ b/SORParser/SORGeneralParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SORGeneralParams {
+struct SORGeneralParams: SORBlock {
     enum FiberType: UInt16 {
         case multiMode = 651 // ITU-T G.651 (multi-mode fiber)
         case standardSingleMode = 652 // ITU-T G.652 (standard single-mode fiber)

--- a/SORParser/SORKeyEvents.swift
+++ b/SORParser/SORKeyEvents.swift
@@ -15,7 +15,7 @@ struct SOREvent {
     let comment: String
 }
 
-struct SORKeyEvents {
+struct SORKeyEvents: SORBlock {
     let totalLoss: UInt16
     let fiberStartPosition: Int32
     let fiberLength: UInt32

--- a/SORParser/SORSupplierParams.swift
+++ b/SORParser/SORSupplierParams.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct SORSupplierParams {
+struct SORSupplierParams: SORBlock {
     let supplierName: String
     let OTDRName: String
     let OTDRSerialNumber: String

--- a/SORParser/main.swift
+++ b/SORParser/main.swift
@@ -18,28 +18,26 @@ func parseFile(at path: String) {
     
     if let map = SORMap(from: fileHandle) {
         print(map)
-        if let genParams = SORGeneralParams(from: fileHandle, header: map.dataHeaders[0]) {
-            print(genParams)
-        }
-        
-        if let supParams = SORSupplierParams(from: fileHandle, header: map.dataHeaders[1]) {
-            print(supParams)
-        }
-        
-        if let fixedParams = SORFixedParams(from: fileHandle, header: map.dataHeaders[2]) {
-            print(fixedParams)
-        }
-        
-        if let keyEvents = SORKeyEvents(from: fileHandle, header: map.dataHeaders[3]) {
-            print(keyEvents)
-        }
-        
-        if let dataPoints = SORDataPoints(from: fileHandle, header: map.dataHeaders[4]) {
-            print(dataPoints)
-        }
-        
-        if let chkSum = SORCheckSum(from: fileHandle, header: map.dataHeaders[5]) {
-            print(chkSum)
+
+        let blocks: [SORBlock.Type] = [
+            SORGeneralParams.self,
+            SORSupplierParams.self,
+            SORFixedParams.self,
+            SORKeyEvents.self,
+            SORDataPoints.self,
+            SORCheckSum.self
+        ]
+
+        for (idx, block) in blocks.enumerated() {
+            guard map.dataHeaders.indices.contains(idx) else {
+                fatalError("Invalid block index: \(idx)")
+            }
+            
+            if let data = block.init(from: fileHandle, header: map.dataHeaders[idx]) {
+                print(data)
+            } else {
+                print("Unable to get data for block: \(map.dataHeaders[idx].name)")
+            }
         }
     }
 }


### PR DESCRIPTION
SORBlock protocol has beed added.
Now we can use the same initialiser for all types of data blocks from SOR map.
Base parsing logic has been refactored accordingly.